### PR TITLE
use openapi-spec-validator instead of swagger-validator

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -11,7 +11,6 @@ test:
 
 docker-pull:
 	docker pull p0bailey/docker-flask
-	docker pull swaggerapi/swagger-validator
 	docker pull wazopbx/wait
 	docker pull wazopbx/postgres
 	docker pull wazopbx/postgres-test

--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -3,11 +3,5 @@ services:
   sync:
     depends_on:
       - call-logd
-      - swagger-validator
     environment:
-      TARGETS: "call-logd:9298 swagger-validator:8080"
-
-  swagger-validator:
-    image: swaggerapi/swagger-validator
-    ports:
-      - "8080"
+      TARGETS: "call-logd:9298"

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,12 +1,16 @@
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 import requests
-import pprint
+import yaml
 
-from hamcrest import assert_that, empty
+from openapi_spec_validator import validate_v2_spec
 
 from .helpers.base import IntegrationTest
+
+logger = logging.getLogger('openapi_spec_validator')
+logger.setLevel(logging.INFO)
 
 
 class TestDocumentation(IntegrationTest):
@@ -14,11 +18,7 @@ class TestDocumentation(IntegrationTest):
     asset = 'documentation'
 
     def test_documentation_errors(self):
-        api_url = 'https://call-logd:9298/1.0/api/api.yml'
-        self.validate_api(api_url)
-
-    def validate_api(self, url):
-        port = self.service_port(8080, 'swagger-validator')
-        validator_url = 'http://localhost:{port}/debug'.format(port=port)
-        response = requests.get(validator_url, params={'url': url})
-        assert_that(response.json(), empty(), pprint.pformat(response.json()))
+        port = self.service_port(9298, 'call-logd')
+        api_url = 'https://localhost:{port}/1.0/api/api.yml'.format(port=port)
+        api = requests.get(api_url, verify=False)
+        validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -6,6 +6,7 @@ https://github.com/wazo-pbx/xivo-lib-python/archive/master.zip
 docker-compose
 kombu
 nose
+openapi-spec-validator
 psycopg2-binary  # from sqlalchemy
 pyhamcrest
 requests


### PR DESCRIPTION
reason: openapi-spec-validator catch more errors