### PR TITLE
token_renewer: use new callback signature

### DIFF
--- a/wazo_call_logd/bin/main.py
+++ b/wazo_call_logd/bin/main.py
@@ -86,7 +86,9 @@ def _generate_call_logs():
     auth_client = AuthClient(**config['auth'])
     confd_client = ConfdClient(**config['confd'])
     token_renewer = TokenRenewer(auth_client)
-    token_renewer.subscribe_to_token_change(confd_client.set_token)
+    token_renewer.subscribe_to_token_change(
+        lambda token: confd_client.set_token(token['token'])
+    )
 
     cel_fetcher = CELFetcher()
     generator = CallLogsGenerator([

--- a/wazo_call_logd/controller.py
+++ b/wazo_call_logd/controller.py
@@ -42,7 +42,9 @@ class Controller(object):
         self.bus_client = BusClient(config)
         self.rest_api = CoreRestApi(config)
         self.token_renewer = TokenRenewer(auth_client)
-        self.token_renewer.subscribe_to_token_change(confd_client.set_token)
+        self.token_renewer.subscribe_to_token_change(
+            lambda token: confd_client.set_token(token['token'])
+        )
         self.status_aggregator = StatusAggregator()
         self.token_status = TokenStatus()
         plugin_helpers.load(


### PR DESCRIPTION
token_renewer now passes the whole token object to callbacks